### PR TITLE
Added context menu option: open with default browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,15 @@
                 "mac": "cmd+k d",
                 "when": "editorTextFocus && editorLangId == html"
             }
-        ]
+        ],
+		"menus": {
+			"explorer/context": [
+				{
+					"command": "extension.openWithDefault",
+					"group": "navigation@1"
+				}
+			]
+		}
     },
     "scripts": {
         "postinstall": "node ./node_modules/vscode/bin/install",


### PR DESCRIPTION
Added an option in the context menu in the visual studio code explorer to open a file in the default browser